### PR TITLE
Match full variety of Content-Type values

### DIFF
--- a/Request/RequestRefreshToken.php
+++ b/Request/RequestRefreshToken.php
@@ -18,7 +18,7 @@ class RequestRefreshToken
     public static function getRefreshToken(Request $request)
     {
         $refreshTokenString = null;
-        if ($request->headers->get('content_type') == 'application/json') {
+        if (0 === strpos($request->getContentType(), 'application/json')) {
             $content = $request->getContent();
             $params = !empty($content) ? json_decode($content, true) : array();
             $refreshTokenString = isset($params['refresh_token']) ? trim($params['refresh_token']) : null;


### PR DESCRIPTION
At the moment the "Content-Type" header must be exactly 'application/json' for the refresh token to be extracted from the request. 

It is valid for "Content-Type" header to have a parameter for example 'application/json;charset=UTF-8', but this does not match the criteria and so the refresh fails. 

This change checks that the Content-Type header starts with  'application/json' and will then attempt to extract refresh_token from the content of the request.